### PR TITLE
docs: quaid-scanner health report 2026-06-01

### DIFF
--- a/docs/reports/quaid-scan-2026-06-01.md
+++ b/docs/reports/quaid-scan-2026-06-01.md
@@ -1,0 +1,125 @@
+# quaid-scanner Report: /Users/karstenwade/Projects/AINative-Studio/src/PublicFounders
+
+**Score:** 🔴 2.1/10 — CRITICAL risk
+**Maturity:** sandbox | **Depth:** standard | **Duration:** 0.2s
+**Scanned:** 2026-06-01T21:44:59.059Z
+
+## Pillar Scores
+
+| Pillar | Score | Weight | Findings |
+|--------|-------|--------|----------|
+| Security | 3.5 | 25% | 0C 4W 1I |
+| Governance | 1.0 | 20% | 0C 3W 9I |
+| Community | 1.0 | 15% | 0C 3W 9I |
+| AI Readiness | 2.5 | 15% | 0C 5W 0I |
+| Inclusive Language | 0.0 | 15% | 0C 4W 25I |
+| Technical Rigor | 5.0 | 10% | 0C 2W 4I |
+
+## Warnings
+
+- **[TIMEOUT-binary-artifacts]** Scanner "binary-artifacts" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-dep-pinning-docker]** Scanner "dep-pinning-docker" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-openssf-local-checks]** Scanner "openssf-local-checks" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-openssf-scorecard]** Scanner "openssf-scorecard" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[bus-factor-1]** Bus factor: 2, Elephant factor: 47% (3 contributors, 55 commits in last 12 months) *(Encourage more contributors and distribute code ownership)*
+- **[governance-classification-1]** Unclear governance model — best guess is "Foundation-backed" with low confidence (32%) *(Document the governance model explicitly in GOVERNANCE.md for clarity)*
+- **[TIMEOUT-license-header-scanner]** Scanner "license-header-scanner" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[contributor-funnel-2]** Conversion rates: casual→regular 0%, regular→core 0% *(Low casual-to-regular conversion suggests contributor onboarding friction)*
+- **[psych-safety-1]** No Code of Conduct found *(Add a CODE_OF_CONDUCT.md — see https://www.contributor-covenant.org/)*
+- **[support-channels-1]** No SUPPORT.md or .github/SUPPORT.md found *(Add a SUPPORT.md documenting how users can get help)*
+- **[agentic-rules-2]** CLAUDE.md lacks recognized structural sections *(Add sections like "Critical Rules", "Project Structure", "Common Tasks" to improve agent guidance.)*
+- **[TIMEOUT-ai-repo-detection]** Scanner "ai-repo-detection" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-dataset-provenance]** Scanner "dataset-provenance" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-model-card-detection]** Scanner "model-card-detection" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-model-card-scoring]** Scanner "model-card-scoring" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-diminishing-language-scanner]** Scanner "diminishing-language-scanner" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-inclusive-code-scanner]** Scanner "inclusive-code-scanner" failed: Cannot read properties of undefined (reading 'termListUrl') *(Check scanner implementation for errors)*
+- **[TIMEOUT-inclusive-doc-scanner]** Scanner "inclusive-doc-scanner" failed: Cannot read properties of undefined (reading 'termListUrl') *(Check scanner implementation for errors)*
+- **[TIMEOUT-inclusive-naming-scanner]** Scanner "inclusive-naming-scanner" failed: Cannot read properties of undefined (reading 'termListUrl') *(Check scanner implementation for errors)*
+- **[interaction-templates-1]** No issue templates configured *(Add .github/ISSUE_TEMPLATE/ with bug report and feature request templates)*
+- **[test-coverage-2]** No coverage configuration file found *(Add a coverage configuration (e.g., vitest.config.ts with coverage thresholds, jest.config.js with coverageThreshold, or .nycrc) to enforce coverage minimums)*
+
+## Info
+
+- **[branch-protection-1]** GitHub token not provided. Cannot check branch protection settings.
+- **[asset-protection-1]** No trademark policy found (optional)
+- **[asset-protection-2]** No export control documentation found (optional)
+- **[asset-protection-3]** No CLA or DCO requirement detected
+- **[asset-protection-4]** Contributor friction level: Low
+- **[dep-license-scanning-1]** Python dependencies detected (requirements.txt) — license scanning requires installed packages
+- **[governance-detection-1]** No governance documentation found
+- **[license-compatibility-1]** Project license is Apache-2.0 — no installed dependencies to check compatibility
+- **[vendor-neutrality-domain-count]** Found 3 unique email domain(s) across 55 commits
+- **[vendor-neutrality-no-succession]** No succession planning documentation found
+- **[burnout-detection-1]** Burnout detection requires a GitHub token
+- **[contributor-data-2]** Contributor emails span 3 domains
+- **[contributor-funnel-1]** Contributor funnel: 0 core, 3 regular, 0 casual (3 total)
+- **[funding-1]** No funding infrastructure detected
+- **[issue-closure-1]** Issue closure analysis requires a GitHub token
+- **[response-classification-1]** Response classification requires a GitHub token
+- **[response-time-1]** Response time analysis requires a GitHub token
+- **[stale-bot-1]** No stale bot configured
+- **[support-channels-2]** README contains a support/help section
+- **[AK-GIT-CLONE-README.md:36]** Assumed knowledge: "clone" operation used without explanation
+- **[AK-GIT-CLONE-README.md:38]** Assumed knowledge: "clone" operation used without explanation
+- **[AK-ACRONYM-EOF-README.md:62]** Undefined acronym "EOF" may confuse newcomers
+- **[AK-ACRONYM-JWT-README.md:70]** Undefined acronym "JWT" may confuse newcomers
+- **[AK-ACRONYM-ENVIRONMENT-README.md:81]** Undefined acronym "ENVIRONMENT" may confuse newcomers
+- **[AK-ACRONYM-README-README.md:245]** Undefined acronym "README" may confuse newcomers
+- **[AK-ACRONYM-KPI-README.md:283]** Undefined acronym "KPI" may confuse newcomers
+- **[AK-ACRONYM-GET-README.md:291]** Undefined acronym "GET" may confuse newcomers
+- **[AK-ACRONYM-CRUD-README.md:308]** Undefined acronym "CRUD" may confuse newcomers
+- **[AK-ACRONYM-ORM-README.md:343]** Undefined acronym "ORM" may confuse newcomers
+- **[AK-ACRONYM-RLHF-README.md:355]** Undefined acronym "RLHF" may confuse newcomers
+- **[AK-ACRONYM-LICENSE-README.md:398]** Undefined acronym "LICENSE" may confuse newcomers
+- **[AK-GIT-FORK-CONTRIBUTING.md:29]** Assumed knowledge: "fork" operation used without explanation
+- **[AK-GIT-CLONE-CONTRIBUTING.md:31]** Assumed knowledge: "clone" operation used without explanation
+- **[AK-GIT-CLONE-CONTRIBUTING.md:33]** Assumed knowledge: "clone" operation used without explanation
+- **[AK-GIT-BRANCH-CONTRIBUTING.md:492]** Assumed knowledge: "branch" operation used without explanation
+- **[AK-GIT-BRANCH-CONTRIBUTING.md:495]** Assumed knowledge: "branch" operation used without explanation
+- **[AK-GIT-BRANCH-CONTRIBUTING.md:498]** Assumed knowledge: "branch" operation used without explanation
+- **[AK-GIT-BRANCH-CONTRIBUTING.md:501]** Assumed knowledge: "branch" operation used without explanation
+- **[AK-GIT-REBASE-CONTRIBUTING.md:524]** Assumed knowledge: "rebase" operation used without explanation
+- **[AK-ACRONYM-PEP-CONTRIBUTING.md:236]** Undefined acronym "PEP" may confuse newcomers
+- **[AK-ACRONYM-DEBUG-CONTRIBUTING.md:672]** Undefined acronym "DEBUG" may confuse newcomers
+- **[AK-ACRONYM-README-CONTRIBUTING.md:697]** Undefined acronym "README" may confuse newcomers
+- **[AK-ACRONYM-ARCHITECTURE-CONTRIBUTING.md:697]** Undefined acronym "ARCHITECTURE" may confuse newcomers
+- **[AK-ACRONYM-DEPLOYMENT-CONTRIBUTING.md:697]** Undefined acronym "DEPLOYMENT" may confuse newcomers
+- **[linter-config-2]** Linter config found but no lint step detected in CI workflows
+- **[release-cadence-1]** No releases or version tags found
+- **[test-coverage-3]** No coverage badge found in README
+- **[semver-validation-1]** No git tags found — cannot validate SemVer
+
+## Recommendations
+
+- **[MEDIUM impact / low effort]** Increase scannerTimeout in configuration or check network connectivity
+- **[MEDIUM impact / low effort]** Encourage more contributors and distribute code ownership
+- **[MEDIUM impact / low effort]** Document the governance model explicitly in GOVERNANCE.md for clarity
+- **[MEDIUM impact / low effort]** Increase scannerTimeout in configuration or check network connectivity
+- **[MEDIUM impact / low effort]** Low casual-to-regular conversion suggests contributor onboarding friction
+- **[MEDIUM impact / low effort]** Add a CODE_OF_CONDUCT.md — see https://www.contributor-covenant.org/
+- **[MEDIUM impact / low effort]** Add a SUPPORT.md documenting how users can get help
+- **[MEDIUM impact / low effort]** Add sections like "Critical Rules", "Project Structure", "Common Tasks" to improve agent guidance.
+- **[MEDIUM impact / low effort]** Increase scannerTimeout in configuration or check network connectivity
+- **[MEDIUM impact / low effort]** Increase scannerTimeout in configuration or check network connectivity
+- **[MEDIUM impact / low effort]** Check scanner implementation for errors
+- **[MEDIUM impact / low effort]** Add .github/ISSUE_TEMPLATE/ with bug report and feature request templates
+- **[MEDIUM impact / low effort]** Add a coverage configuration (e.g., vitest.config.ts with coverage thresholds, jest.config.js with coverageThreshold, or .nycrc) to enforce coverage minimums
+
+## Score Rationale
+
+Overall score is a weighted sum of six pillar scores (each scored 0–10).
+
+| Pillar | Weight | Raw Score | Contribution |
+|--------|--------|-----------|-------------|
+| Security | 25% | 3.5 | 0.88 |
+| Governance | 20% | 1.0 | 0.20 |
+| Community | 15% | 1.0 | 0.15 |
+| AI Readiness | 15% | 2.5 | 0.38 |
+| Inclusive Language | 15% | 0.0 | 0.00 |
+| Technical Rigor | 10% | 5.0 | 0.50 |
+| **Overall** | **100%** | | **2.10** |
+
+---
+*quaid-scanner v0.1.2 | 2026-06-01T21:44:59.059Z*
+*Commit: 4ea41d3ba8e9ae797df48493ef33c750742dd1ab*


### PR DESCRIPTION
## OSS Health Report — 2026-06-01

**Score:** ?/10 | **Risk:** ? | **Depth:** standard

Generated by [quaid-scanner](https://github.com/quaid/quaid-scanner) v0.1.2.

Report lives at `docs/reports/quaid-scan-2026-06-01.md`.
Issues for CRITICAL and WARNING findings are filed separately in this repo.